### PR TITLE
Small bug fix for creating blank ADF and running on Current MacOS

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -11,6 +11,9 @@ pyinstaller = "*"
 [packages]
 amitools = "*"
 pyqt5 = "*"
+lhafile = "*"
+pyqt5-qt5 = "*"
+pyqt5-sip = "*"
 
 [requires]
-python_version = "3.7"
+python_version = "3.11.14"

--- a/Pipfile
+++ b/Pipfile
@@ -14,6 +14,3 @@ pyqt5 = "*"
 lhafile = "*"
 pyqt5-qt5 = "*"
 pyqt5-sip = "*"
-
-[requires]
-python_version = "3.11.14"

--- a/adf.py
+++ b/adf.py
@@ -20,6 +20,11 @@ class ADF():
 
     def create(self, path):
         self.cleanUp()
+        
+        #NOTE: Was crashing saying unrecognize file type is I entered blankdisk, I needed blankdisk.adf
+        # This code just checks and adds .adf to the end if missing.
+        if not path.endswith(".adf"):
+            path += ".adf"
 
         self.blkdev = BlkDevFactory().create(path)
         self.volume = ADFSVolume(self.blkdev)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
-amitools==0.5.0
-lhafile==0.2.2
-PyQt5==5.15.0
-PyQt5-sip==12.8.0
+amitools==0.7.0
+lhafile==0.3.0
+pyqt5==5.15.9
+pyqt5-qt5==5.15.2
+pyqt5-sip==12.12.1 


### PR DESCRIPTION
Hi! Ran into a bug, didn't realized I had to have a valid extension. This just adds .adf to a filename when creating a blank image to make things more user friendly, as well as tested on all the latest required packages.

I cleaned up the requirements.txt and the Pipefile too :)